### PR TITLE
fixes download error in macosx

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -2,7 +2,7 @@
 # This software may be used and distributed according to the terms of the GNU General Public License version 3.
 
 PRESIGNED_URL=""             # replace with presigned url from email
-MODEL_SIZE="7B,13B,30B,65B"  # edit this list with the model sizes you wish to download
+MODEL_SIZE="7,13,30,65"  # edit this list with the model sizes you wish to download
 TARGET_FOLDER=""             # where all files should end up
 
 declare -A N_SHARD_DICT
@@ -20,14 +20,14 @@ wget ${PRESIGNED_URL/'*'/"tokenizer_checklist.chk"} -O ${TARGET_FOLDER}"/tokeniz
 
 for i in ${MODEL_SIZE//,/ }
 do
-    echo "Downloading ${i}"
-    mkdir -p ${TARGET_FOLDER}"/${i}"
+    echo "Downloading ${i}B"
+    mkdir -p ${TARGET_FOLDER}"/${i}B"
     for s in $(seq -f "0%g" 0 ${N_SHARD_DICT[$i]})
     do
-        wget ${PRESIGNED_URL/'*'/"${i}/consolidated.${s}.pth"} -O ${TARGET_FOLDER}"/${i}/consolidated.${s}.pth"
+        wget ${PRESIGNED_URL/'*'/"${i}B/consolidated.${s}.pth"} -O ${TARGET_FOLDER}"/${i}B/consolidated.${s}.pth"
     done
-    wget ${PRESIGNED_URL/'*'/"${i}/params.json"} -O ${TARGET_FOLDER}"/${i}/params.json"
-    wget ${PRESIGNED_URL/'*'/"${i}/checklist.chk"} -O ${TARGET_FOLDER}"/${i}/checklist.chk"
+    wget ${PRESIGNED_URL/'*'/"${i}B/params.json"} -O ${TARGET_FOLDER}"/${i}B/params.json"
+    wget ${PRESIGNED_URL/'*'/"${i}B/checklist.chk"} -O ${TARGET_FOLDER}"/${i}B/checklist.chk"
     echo "Checking checksums"
-    (cd ${TARGET_FOLDER}"/${i}" && md5sum -c checklist.chk)
+    (cd ${TARGET_FOLDER}"/${i}B" && md5sum -c checklist.chk)
 done


### PR DESCRIPTION
The current download script gives error when executed on Mac. 

download.sh: line 10: 7B: value too great for base (error token is "7B")
download.sh: line 11: 13B: value too great for base (error token is "13B")
download.sh: line 12: 30B: value too great for base (error token is "30B")
download.sh: line 13: 65B: value too great for base (error token is "65B")

The pull request fixes this.