### PR TITLE
Added curl and curl flag option on bash

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -1,6 +1,20 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # This software may be used and distributed according to the terms of the GNU General Public License version 3.
 
+
+while getopts "v:" option; do
+  case "${option}" in
+    v) variant="${OPTARG}" ;;
+    *) echo "Invalid option" ; exit 1 ;;
+  esac
+done
+
+if [ -z "${variant}" ]; then
+  variant="wget"
+fi
+
+
+
 PRESIGNED_URL=""             # replace with presigned url from email
 MODEL_SIZE="7B,13B,30B,65B"  # edit this list with the model sizes you wish to download
 TARGET_FOLDER=""             # where all files should end up
@@ -13,8 +27,13 @@ N_SHARD_DICT["30B"]="3"
 N_SHARD_DICT["65B"]="7"
 
 echo "Downloading tokenizer"
-wget ${PRESIGNED_URL/'*'/"tokenizer.model"} -O ${TARGET_FOLDER}"/tokenizer.model"
-wget ${PRESIGNED_URL/'*'/"tokenizer_checklist.chk"} -O ${TARGET_FOLDER}"/tokenizer_checklist.chk"
+if [ "${variant}" == "curl" ]; then
+  curl ${PRESIGNED_URL/'*'/"tokenizer.model"} -o ${TARGET_FOLDER}"/tokenizer.model"
+  curl ${PRESIGNED_URL/'*'/"tokenizer_checklist.chk"} -o ${TARGET_FOLDER}"/tokenizer_checklist.chk"
+else
+  wget ${PRESIGNED_URL/'*'/"tokenizer.model"} -O ${TARGET_FOLDER}"/tokenizer.model"
+  wget ${PRESIGNED_URL/'*'/"tokenizer_checklist.chk"} -O ${TARGET_FOLDER}"/tokenizer_checklist.chk"
+fi
 
 (cd ${TARGET_FOLDER} && md5sum -c tokenizer_checklist.chk)
 
@@ -24,10 +43,19 @@ do
     mkdir -p ${TARGET_FOLDER}"/${i}"
     for s in $(seq -f "0%g" 0 ${N_SHARD_DICT[$i]})
     do
-        wget ${PRESIGNED_URL/'*'/"${i}/consolidated.${s}.pth"} -O ${TARGET_FOLDER}"/${i}/consolidated.${s}.pth"
+        if [ "${variant}" == "curl" ]; then
+            curl ${PRESIGNED_URL/'*'/"${i}/consolidated.${s}.pth"} -o ${TARGET_FOLDER}"/${i}/consolidated.${s}.pth"
+        else
+            wget ${PRESIGNED_URL/'*'/"${i}/consolidated.${s}.pth"} -O ${TARGET_FOLDER}"/${i}/consolidated.${s}.pth"
+        fi
     done
-    wget ${PRESIGNED_URL/'*'/"${i}/params.json"} -O ${TARGET_FOLDER}"/${i}/params.json"
-    wget ${PRESIGNED_URL/'*'/"${i}/checklist.chk"} -O ${TARGET_FOLDER}"/${i}/checklist.chk"
+    if [ "${variant}" == "curl" ]; then
+        curl ${PRESIGNED_URL/'*'/"${i}/params.json"} -o ${TARGET_FOLDER}"/${i}/params.json"
+        curl ${PRESIGNED_URL/'*'/"${i}/checklist.chk"} -o ${TARGET_FOLDER}"/${i}/checklist.chk"
+    else
+        wget ${PRESIGNED_URL/'*'/"${i}/params.json"} -O ${TARGET_FOLDER}"/${i}/params.json"
+        wget ${PRESIGNED_URL/'*'/"${i}/checklist.chk"} -O ${TARGET_FOLDER}"/${i}/checklist.chk"
+    fi
     echo "Checking checksums"
     (cd ${TARGET_FOLDER}"/${i}" && md5sum -c checklist.chk)
 done


### PR DESCRIPTION
Added an option for non-Linux users to select between using `wget` or curl to download files using this script. 

To use `curl`, simply include the `-v curl ` flag when running the script. If no flag is specified, `wget` is used by default. 

This allows for greater flexibility and ease of use across different platforms.