### PR TITLE
changed max_seq_len 1024 to 2048

### DIFF
--- a/llama/model.py
+++ b/llama/model.py
@@ -27,7 +27,7 @@ class ModelArgs:
     norm_eps: float = 1e-5
 
     max_batch_size: int = 32
-    max_seq_len: int = 1024
+    max_seq_len: int = 2048
 
 
 class RMSNorm(torch.nn.Module):


### PR DESCRIPTION
The models support a 2048 context window. This is not well advertised and people are getting confused. No sense having a smaller size here, as it just adds to the confusion.