### PR TITLE
Add support for generating multiple prompts with max_batch_size=1

### DIFF
--- a/example.py
+++ b/example.py
@@ -106,13 +106,18 @@ plush girafe => girafe peluche
 
 cheese =>""",
     ]
-    results = generator.generate(
-        prompts, max_gen_len=256, temperature=temperature, top_p=top_p
-    )
+    if max_batch_size==1:
+        for prompt in prompts:
+            print(generator.generate([prompt], max_gen_len=256, temperature=temperature, top_p=top_p))
+            print("\n==================================\n")
+    else:    
+        results = generator.generate(
+            prompts, max_gen_len=256, temperature=temperature, top_p=top_p
+        )
 
-    for result in results:
-        print(result)
-        print("\n==================================\n")
+        for result in results:
+            print(result)
+            print("\n==================================\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds the ability to generate multiple prompts with a batch size of 1. Previously, only a single prompt could be generated at a time when max_batch_size was set to 1. With this change, the generate function now accepts a list of prompts and generates each one sequentially. Additionally, the code now prints each generated result immediately after it is generated to make it easier to read the results. 