### PR TITLE
Change model license to Apache License, Version 2.0

### DIFF
--- a/MODEL_CARD.md
+++ b/MODEL_CARD.md
@@ -20,7 +20,7 @@ More information can be found in the paper “LLaMA, Open and Efficient Foundati
 https://research.facebook.com/publications/llama-open-and-efficient-foundation-language-models/
 
 **License**
-Non-commercial bespoke license
+Apache 2.0
 
 **Where to send questions or comments about the model**
 Questions and comments about LLaMA can be sent via the [GitHub repository](https://github.com/facebookresearch/llama) of the project , by opening an issue.


### PR DESCRIPTION
From an economical and ecological perspective the current "Non-commercial bespoke" model license is sub-optimal and should be changed to a truly liberal open-source license like for example Apache 2.0.

In the current state Meta published the whole replication recipe open-source (GPL v3) but asks other entities to spend a lot of energy (potentially releasing massive amounts of CO2 into the atmosphere) to replicate and release a truly open-source version of LLaMA. Given the fact that LLaMA model weights are currently already available for download at many different places this is from an ecological perspective a preposterous management decision and in my personal opinion not well aligned with the overall ecological ambitions of Meta.

If you say "open" (as in the LLaMA paper) and you want to get the bonus credibility that comes with it .. please do it fully and not half-hearted as done currently.
