### PR TITLE
Support CPU inference with a flag

### DIFF
--- a/llama/generation.py
+++ b/llama/generation.py
@@ -10,9 +10,10 @@ from llama.model import Transformer
 
 
 class LLaMA:
-    def __init__(self, model: Transformer, tokenizer: Tokenizer):
+    def __init__(self, model: Transformer, tokenizer: Tokenizer, is_gpu: bool):
         self.model = model
         self.tokenizer = tokenizer
+        self.is_gpu = is_gpu
 
     def generate(
         self,
@@ -31,8 +32,9 @@ class LLaMA:
         max_prompt_size = max([len(t) for t in prompt_tokens])
 
         total_len = min(params.max_seq_len, max_gen_len + max_prompt_size)
+        tokens = torch.full((bsz, total_len), self.tokenizer.pad_id)
+        tokens = tokens.cuda().long() if self.is_gpu else tokens.long()
 
-        tokens = torch.full((bsz, total_len), self.tokenizer.pad_id).cuda().long()
         for k, t in enumerate(prompt_tokens):
             tokens[k, : len(t)] = torch.tensor(t).long()
         input_text_mask = tokens != self.tokenizer.pad_id

--- a/llama/model.py
+++ b/llama/model.py
@@ -29,6 +29,8 @@ class ModelArgs:
     max_batch_size: int = 32
     max_seq_len: int = 2048
 
+    is_gpu: bool = True
+
 
 class RMSNorm(torch.nn.Module):
     def __init__(self, dim: int, eps: float = 1e-6):
@@ -111,10 +113,15 @@ class Attention(nn.Module):
 
         self.cache_k = torch.zeros(
             (args.max_batch_size, args.max_seq_len, self.n_local_heads, self.head_dim)
-        ).cuda()
+        )
+        if args.is_gpu:
+            self.cache_k = self.cache_k.cuda()
+
         self.cache_v = torch.zeros(
             (args.max_batch_size, args.max_seq_len, self.n_local_heads, self.head_dim)
-        ).cuda()
+        )
+        if args.is_gpu:
+            self.cache_v = self.cache_v.cuda()
 
     def forward(self, x: torch.Tensor, start_pos: int, freqs_cis: torch.Tensor, mask: Optional[torch.Tensor]):
         bsz, seqlen, _ = x.shape


### PR DESCRIPTION
Many users may have limited GPU memory or no GPUs at all, so cannot run the model. This change is to enable running inference on CPU to bypass the GPU limit.

- Add a flag (`--is_gpu 0`), and support CPU inference when it is set to `False`. 

```
torchrun --nproc_per_node MP example.py --ckpt_dir $TARGET_FOLDER/model_size --tokenizer_path $TARGET_FOLDER/tokenizer.model --is_gpu 0
```

Timer for the same `example.py` on CPU:
```
Loaded in 8.37 seconds
Generated in 192.77 seconds 
```