### PR TITLE
Set numpy version to ~=1.22

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numpy~=1.22
 torch
 fairscale
 fire


### PR DESCRIPTION
After creating a conda environent based off base and installing dependencies:

```
conda create --name facebook-llama --clone base
conda activate facebook-llama
pip install -r requirements.txt
```

I had the following error:

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
daal4py 2021.5.0 requires daal==2021.4.0, which is not installed.
scipy 1.7.3 requires numpy<1.23.0,>=1.16.5, but you have numpy 1.24.2 which is incompatible.
numba 0.55.1 requires numpy<1.22,>=1.18, but you have numpy 1.24.2 which is incompatible.
```

Explicitly setting the numpy version to 1.22.x helped.