### PR TITLE
Dont fail on training with random weights

### DIFF
--- a/llama/model.py
+++ b/llama/model.py
@@ -129,8 +129,12 @@ class Attention(nn.Module):
         self.cache_k = self.cache_k.to(xq)
         self.cache_v = self.cache_v.to(xq)
 
-        self.cache_k[:bsz, start_pos : start_pos + seqlen] = xk
-        self.cache_v[:bsz, start_pos : start_pos + seqlen] = xv
+        with torch.no_grad():
+            # Modiying cache without no_grad causes the autograd engine to track
+            # the updates and leads to "RuntimeError: Trying to backward through
+            # the graph a second time"
+            self.cache_k[:bsz, start_pos : start_pos + seqlen] = xk
+            self.cache_v[:bsz, start_pos : start_pos + seqlen] = xv
 
         keys = self.cache_k[:bsz, : start_pos + seqlen]
         values = self.cache_v[:bsz, : start_pos + seqlen]


### PR DESCRIPTION
I am testing `torch.compile` for this model with random weights. Goal is to see if torch.compile can compile this model, and get some performance speedup numbers.

W/o this PR, running the model fwd-bwd twice causes the exception

`RuntimeError: Trying to backward through the graph a second time`

This is because we are writing into cache_k and cache_v without setting torch.no_grad.

Relevant PR - https://github.com/pytorch/benchmark/pull/1631

cc @xuzhao9 