### PR TITLE
make llama work on more backends with a new parameter `--backend`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LLaMA 
+# LLaMA
 
 This repository is intended as a minimal, hackable and readable example to load [LLaMA](https://ai.facebook.com/blog/large-language-model-llama-meta-ai/) ([arXiv](https://arxiv.org/abs/2302.13971v1)) models and run inference.
 In order to download the checkpoints and tokenizer, fill this [google form](https://forms.gle/jk851eBVbX1m5TAv5)
@@ -34,6 +34,9 @@ Different models require different MP values:
 | 13B    | 2  |
 | 33B    | 4  |
 | 65B    | 8  |
+
+Optionally, use `--backend` to select a [device type](https://pytorch.org/docs/stable/tensor_attributes.html#torch.device) other than the default `cuda`,
+for example, `--backend cpu`. [DirectML](https://github.com/microsoft/DirectML) can be selected by `--backend directml`.
 
 ## FAQ
 

--- a/llama/generation.py
+++ b/llama/generation.py
@@ -13,6 +13,7 @@ class LLaMA:
     def __init__(self, model: Transformer, tokenizer: Tokenizer):
         self.model = model
         self.tokenizer = tokenizer
+        self.device = model.device
 
     def generate(
         self,
@@ -32,7 +33,7 @@ class LLaMA:
 
         total_len = min(params.max_seq_len, max_gen_len + max_prompt_size)
 
-        tokens = torch.full((bsz, total_len), self.tokenizer.pad_id).cuda().long()
+        tokens = torch.full((bsz, total_len), self.tokenizer.pad_id).to(self.device).long()
         for k, t in enumerate(prompt_tokens):
             tokens[k, : len(t)] = torch.tensor(t).long()
         input_text_mask = tokens != self.tokenizer.pad_id


### PR DESCRIPTION
Comparing with PR #253, this one adds a new parmeter `--backend`, which allows more options
besides `cuda` and `cpu`.