### PR TITLE
Enable dynamo export: remove unnecessary model attribute assignment on 'freqs_cis'

### DIFF
--- a/llama/model.py
+++ b/llama/model.py
@@ -223,8 +223,8 @@ class Transformer(nn.Module):
     def forward(self, tokens: torch.Tensor, start_pos: int):
         _bsz, seqlen = tokens.shape
         h = self.tok_embeddings(tokens)
-        self.freqs_cis = self.freqs_cis.to(h.device)
-        freqs_cis = self.freqs_cis[start_pos : start_pos + seqlen]
+        freqs_cis = self.freqs_cis.to(h.device)
+        freqs_cis = freqs_cis[start_pos : start_pos + seqlen]
 
         mask = None
         if seqlen > 1:


### PR DESCRIPTION
Otherwise a graph break is triggered.

```
        Mutating module attribute freqs_cis during export.
        
        from user code:
           File "/bert_ort/bowbao/repos/bench/torchbenchmark/torchbenchmark/models/llama/model.py", line 227, in forward
            self.freqs_cis = self.freqs_cis.to(h.device)
        
        Set TORCH_LOGS="+dynamo" and TORCHDYNAMO_VERBOSE=1 for more information
        
        
        You can suppress this exception and fall back to eager by setting:
            import torch._dynamo
            torch._dynamo.config.suppress_errors = True       
```
Unblocks #https://github.com/pytorch/benchmark/pull/1766 to fix https://github.com/pytorch/benchmark/issues/1767.