### PR TITLE
make llama V2 work on more backends with a new parameter --backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Llama 2
 
-We are unlocking the power of large language models. Our latest version of Llama is now accessible to individuals, creators, researchers and businesses of all sizes so that they can experiment, innovate and scale their ideas responsibly. 
+We are unlocking the power of large language models. Our latest version of Llama is now accessible to individuals, creators, researchers and businesses of all sizes so that they can experiment, innovate and scale their ideas responsibly.
 
 This release includes model weights and starting code for pretrained and fine-tuned Llama language models — ranging from 7B to 70B parameters.
 
@@ -27,6 +27,8 @@ In a conda env with PyTorch / CUDA available, clone the repo and run in the top-
 ```
 pip install -e .
 ```
+
+It is also possible to test models without CUDA. For example, to run models on CPU, add an extra command line option `--device cpu` to following examples. Number of threads can be set using the environment variable `NUM_THREADS`.
 
 ## Inference
 
@@ -84,7 +86,7 @@ See [MODEL_CARD.md](MODEL_CARD.md).
 
 ## License
 
-Our model and weights are licensed for both researchers and commercial entities, upholding the principles of openness. Our mission is to empower individuals, and industry through this opportunity, while fostering an environment of discovery and ethical AI advancements. 
+Our model and weights are licensed for both researchers and commercial entities, upholding the principles of openness. Our mission is to empower individuals, and industry through this opportunity, while fostering an environment of discovery and ethical AI advancements.
 
 See the [LICENSE](LICENSE) file, as well as our accompanying [Acceptable Use Policy](USE_POLICY.md)
 

--- a/example_chat_completion.py
+++ b/example_chat_completion.py
@@ -11,6 +11,7 @@ from llama import Llama
 def main(
     ckpt_dir: str,
     tokenizer_path: str,
+    backend: str = 'cuda',
     temperature: float = 0.6,
     top_p: float = 0.9,
     max_seq_len: int = 512,
@@ -21,6 +22,7 @@ def main(
         ckpt_dir=ckpt_dir,
         tokenizer_path=tokenizer_path,
         max_seq_len=max_seq_len,
+        backend=backend,
         max_batch_size=max_batch_size,
     )
 

--- a/example_text_completion.py
+++ b/example_text_completion.py
@@ -9,6 +9,7 @@ from llama import Llama
 def main(
     ckpt_dir: str,
     tokenizer_path: str,
+    backend: str = 'cuda',
     temperature: float = 0.6,
     top_p: float = 0.9,
     max_seq_len: int = 128,
@@ -19,6 +20,7 @@ def main(
         ckpt_dir=ckpt_dir,
         tokenizer_path=tokenizer_path,
         max_seq_len=max_seq_len,
+        backend=backend,
         max_batch_size=max_batch_size,
     )
 
@@ -29,11 +31,11 @@ def main(
         """A brief message congratulating the team on the launch:
 
         Hi everyone,
-        
+
         I just """,
         # Few shot prompt (providing a few examples before asking model to complete more);
         """Translate English to French:
-        
+
         sea otter => loutre de mer
         peppermint => menthe poivrée
         plush girafe => girafe peluche

--- a/llama/generation.py
+++ b/llama/generation.py
@@ -56,23 +56,42 @@ class Llama:
         tokenizer_path: str,
         max_seq_len: int,
         max_batch_size: int,
+        backend: str,
         model_parallel_size: Optional[int] = None,
     ) -> "Llama":
-        if not torch.distributed.is_initialized():
-            torch.distributed.init_process_group("nccl")
-        if not model_parallel_is_initialized():
-            if model_parallel_size is None:
-                model_parallel_size = int(os.environ.get("WORLD_SIZE", 1))
+        if model_parallel_size is None:
+            model_parallel_size = int(os.environ.get("WORLD_SIZE", 1))
+
+        device = backend
+
+        if backend == 'cuda':
+            if not torch.distributed.is_initialized():
+                torch.distributed.init_process_group("nccl")
+            if not model_parallel_is_initialized():
+                initialize_model_parallel(model_parallel_size)
+            local_rank = int(os.environ.get("LOCAL_RANK", 0))
+            torch.cuda.set_device(local_rank)
+            if local_rank > 0:
+                sys.stdout = open(os.devnull, "w")
+            torch.set_default_tensor_type(torch.cuda.HalfTensor)
+        else:
+            torch.distributed.init_process_group("gloo")
             initialize_model_parallel(model_parallel_size)
 
-        local_rank = int(os.environ.get("LOCAL_RANK", 0))
-        torch.cuda.set_device(local_rank)
+            if backend == 'directml':
+                import torch_directml
+                torch.set_default_tensor_type(torch_directml.torch.HalfTensor)
+                device = torch_directml.device()
+            elif backend == 'cpu':
+                # Note: some operations such as "addmm_impl_cpu_" are not implemented for 'Half' at present
+                # torch.set_default_tensor_type(torch.HalfTensor)
+                n_threads = int(os.environ.get("NUM_THREADS", 0))
+                if n_threads > 0:
+                    torch.set_num_threads(n_threads)
+                pass
 
         # seed must be the same in all processes
         torch.manual_seed(1)
-
-        if local_rank > 0:
-            sys.stdout = open(os.devnull, "w")
 
         start_time = time.time()
         checkpoints = sorted(Path(ckpt_dir).glob("*.pth"))
@@ -86,13 +105,13 @@ class Llama:
             params = json.loads(f.read())
 
         model_args: ModelArgs = ModelArgs(
+            device=device,
             max_seq_len=max_seq_len,
             max_batch_size=max_batch_size,
             **params,
         )
         tokenizer = Tokenizer(model_path=tokenizer_path)
         model_args.vocab_size = tokenizer.n_words
-        torch.set_default_tensor_type(torch.cuda.HalfTensor)
         model = Transformer(model_args)
         model.load_state_dict(checkpoint, strict=False)
         print(f"Loaded in {time.time() - start_time:.2f} seconds")
@@ -102,6 +121,7 @@ class Llama:
     def __init__(self, model: Transformer, tokenizer: Tokenizer):
         self.model = model
         self.tokenizer = tokenizer
+        self.device = model.device
 
     @torch.inference_mode()
     def generate(
@@ -123,14 +143,14 @@ class Llama:
         total_len = min(params.max_seq_len, max_gen_len + max_prompt_len)
 
         pad_id = self.tokenizer.pad_id
-        tokens = torch.full((bsz, total_len), pad_id, dtype=torch.long, device="cuda")
+        tokens = torch.full((bsz, total_len), pad_id, dtype=torch.long, device=self.device)
         for k, t in enumerate(prompt_tokens):
-            tokens[k, : len(t)] = torch.tensor(t, dtype=torch.long, device="cuda")
+            tokens[k, : len(t)] = torch.tensor(t, dtype=torch.long, device=self.device)
         if logprobs:
             token_logprobs = torch.zeros_like(tokens, dtype=torch.float)
 
         prev_pos = 0
-        eos_reached = torch.tensor([False] * bsz, device="cuda")
+        eos_reached = torch.tensor([False] * bsz, device=self.device)
         input_text_mask = tokens != pad_id
         for cur_pos in range(min_prompt_len, total_len):
             logits = self.model.forward(tokens[:, prev_pos:cur_pos], prev_pos)


### PR DESCRIPTION
With this PR, backend can be set through command line option `--backend`, which defaults to `CUDA`. 

One can test V2 model (at least 7B) on CPU.