### PR TITLE
Update download.sh to not use hardcoded bash path for improved portability

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.


### PR DESCRIPTION
Bash won't always be available at `/bin/bash`, (e.g. on [NixOS](https://nixos.org/)), but `/usr/bin/env bash` is more portable and will generally work on such systems