### PR TITLE
Remove redundant `.float()` in Attention

### DIFF
--- a/llama/model.py
+++ b/llama/model.py
@@ -177,7 +177,7 @@ class Attention(nn.Module):
         scores = torch.matmul(xq, keys.transpose(2, 3)) / math.sqrt(self.head_dim)
         if mask is not None:
             scores = scores + mask  # (bs, n_local_heads, seqlen, cache_len + seqlen)
-        scores = F.softmax(scores.float(), dim=-1).type_as(xq)
+        scores = F.softmax(scores.type_as(xq), dim=-1).type_as(xq)
         output = torch.matmul(scores, values)  # (bs, n_local_heads, seqlen, head_dim)
         output = output.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
         return self.wo(output)


### PR DESCRIPTION
The `.float()` in the Attention layer is not necessary because `F.softmax` internally casts everything to float32, then operates on it, then casts back down to whatever precision you're operating in. Proof:

```
# python3
Python 3.10.6 (main, May 29 2023, 11:10:38) [GCC 11.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import torch
>>>
root@da4e9fb38af4:/llama# python3
Python 3.10.6 (main, May 29 2023, 11:10:38) [GCC 11.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import torch
>>> import torch.nn.functional as F
>>> orig = torch.randn(100000, device="cuda", dtype=torch.bfloat16)
>>> softmaxed = F.softmax(orig, dim=-1)
>>> softmaxed_float = F.softmax(orig.float(), dim=-1).type_as(orig)
>>> (softmaxed_float - softmaxed).abs().sum()
tensor(0., device='cuda:0', dtype=torch.bfloat16)
```

Removing the `.float()` meant I could get a slightly higher batch size without OOMing.