### PR TITLE
Enable resumable download for model parameters

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -49,7 +49,7 @@ do
 
     for s in $(seq -f "0%g" 0 ${SHARD})
     do
-        wget ${PRESIGNED_URL/'*'/"${MODEL_PATH}/consolidated.${s}.pth"} -O ${TARGET_FOLDER}"/${MODEL_PATH}/consolidated.${s}.pth"
+        wget --continue ${PRESIGNED_URL/'*'/"${MODEL_PATH}/consolidated.${s}.pth"} -O ${TARGET_FOLDER}"/${MODEL_PATH}/consolidated.${s}.pth"
     done
 
     wget ${PRESIGNED_URL/'*'/"${MODEL_PATH}/params.json"} -O ${TARGET_FOLDER}"/${MODEL_PATH}/params.json"


### PR DESCRIPTION
Had to turn off my laptop, and then figured I'd continue downloading weights later. Noticed that the default behavior was to redownload every file.

By setting `wget --continue` any existing file will be used as byte offset, and starting downloading again will continue from that offset.

If the remote file changes unexpectedly, I think this could` lead to corrupted files, but I'm assuming these files are seen as static assets. True?