### PR TITLE
Update readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ See `example_text_completion.py` for some examples. To illustrate, see command b
 torchrun --nproc_per_node 1 example_text_completion.py \
     --ckpt_dir llama-2-7b/ \
     --tokenizer_path tokenizer.model \
-    --max_seq_len 128 --max_batch_size 4
+    --max_seq_len 128 --max_batch_size 6
 ```
 
 ### Fine-tuned Chat Models


### PR DESCRIPTION
Default batch_size should be 6 in example_text_completion.py  due to bsz = len(prompt_tokens) where bsz is 6.