### PR TITLE
Return completion log probabilities

### DIFF
--- a/llama/generation.py
+++ b/llama/generation.py
@@ -131,6 +131,15 @@ class Llama:
         prev_pos = 0
         eos_reached = torch.tensor([False] * bsz, device="cuda")
         input_text_mask = tokens != pad_id
+        if min_prompt_len == total_len:
+            logits = self.model.forward(tokens, prev_pos)
+            token_logprobs = -F.cross_entropy(
+                input=logits.transpose(1, 2),
+                target=tokens,
+                reduction="none",
+                ignore_index=pad_id,
+            )
+
         for cur_pos in range(min_prompt_len, total_len):
             logits = self.model.forward(tokens[:, prev_pos:cur_pos], prev_pos)
             if temperature > 0:

--- a/llama/generation.py
+++ b/llama/generation.py
@@ -133,13 +133,6 @@ class Llama:
         input_text_mask = tokens != pad_id
         for cur_pos in range(min_prompt_len, total_len):
             logits = self.model.forward(tokens[:, prev_pos:cur_pos], prev_pos)
-            if logprobs:
-                token_logprobs[:, prev_pos + 1 : cur_pos + 1] = -F.cross_entropy(
-                    input=logits.transpose(1, 2),
-                    target=tokens[:, prev_pos + 1 : cur_pos + 1],
-                    reduction="none",
-                    ignore_index=pad_id,
-                )
             if temperature > 0:
                 probs = torch.softmax(logits[:, -1] / temperature, dim=-1)
                 next_token = sample_top_p(probs, top_p)
@@ -152,6 +145,13 @@ class Llama:
                 input_text_mask[:, cur_pos], tokens[:, cur_pos], next_token
             )
             tokens[:, cur_pos] = next_token
+            if logprobs:
+                token_logprobs[:, prev_pos + 1 : cur_pos + 1] = -F.cross_entropy(
+                    input=logits.transpose(1, 2),
+                    target=tokens[:, prev_pos + 1 : cur_pos + 1],
+                    reduction="none",
+                    ignore_index=pad_id,
+                )
             eos_reached |= (~input_text_mask[:, cur_pos]) & (
                 next_token == self.tokenizer.eos_id
             )


### PR DESCRIPTION
To allow meaningful logprobs for completed tokens, the logprob should be computed after the completed token is sampled.

Running `example_text_completion.py` with `logprob=True` and printing `result['logprobs']` on the first prompt  before the fix
```sh
I believe the meaning of life is
> to be happy. I believe we are
> [-0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0]
```
versus after the fix
```sh
I believe the meaning of life is
> to be happy. I believe we are
> [-0.4371837377548218, -1.7769237756729126, -0.6551999449729919, -0.727012038230896, -1.5545899868011475, -1.2382391691207886, -2.5726795196533203, -1.5549036264419556]
```

This also does not change the prompt logprobs, when `echo=True`.