### PR TITLE
fix line separators in download.sh for wsl2

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -57,4 +57,3 @@ do
     echo "Checking checksums"
     (cd ${TARGET_FOLDER}"/${MODEL_PATH}" && md5sum -c checklist.chk)
 done
-


### PR DESCRIPTION
The original download.sh uses `\r\n` as line separator. On windows by using `wsl2` the shell script can not be executed as seen in https://github.com/facebookresearch/llama/issues/412 .

I replaced the line separators, thus it can be downloaded from windows by using `wsl2` without any problems.