### PR TITLE
fix max_batch_size for chat example

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Examples using llama-2-7b-chat:
 torchrun --nproc_per_node 1 example_chat_completion.py \
     --ckpt_dir llama-2-7b-chat/ \
     --tokenizer_path tokenizer.model \
-    --max_seq_len 512 --max_batch_size 4
+    --max_seq_len 512 --max_batch_size 6
 ```
 
 Llama 2 is a new technology that carries potential risks with use. Testing conducted to date has not — and could not — cover all scenarios.


### PR DESCRIPTION
default prompts size is 6 in example_chat_completion.py, but there is 4 in readme.

```
  File "~/git/llama/llama/generation.py", line 117, in generate
    assert bsz <= params.max_batch_size, (bsz, params.max_batch_size)
AssertionError: (6, 4)
```