### PR TITLE
use 'md5' instead of 'md5sum' if Applie Silicon

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -20,7 +20,12 @@ wget --continue ${PRESIGNED_URL/'*'/"USE_POLICY.md"} -O ${TARGET_FOLDER}"/USE_PO
 echo "Downloading tokenizer"
 wget --continue ${PRESIGNED_URL/'*'/"tokenizer.model"} -O ${TARGET_FOLDER}"/tokenizer.model"
 wget --continue ${PRESIGNED_URL/'*'/"tokenizer_checklist.chk"} -O ${TARGET_FOLDER}"/tokenizer_checklist.chk"
-(cd ${TARGET_FOLDER} && md5sum -c tokenizer_checklist.chk)
+CPU_ARCH=$(uname -m)
+  if [ "$CPU_ARCH" = "arm64" ]; then
+    (cd ${TARGET_FOLDER} && md5 tokenizer_checklist.chk)
+  else
+    (cd ${TARGET_FOLDER} && md5sum -c tokenizer_checklist.chk)
+  fi
 
 for m in ${MODEL_SIZE//,/ }
 do
@@ -55,5 +60,9 @@ do
     wget --continue ${PRESIGNED_URL/'*'/"${MODEL_PATH}/params.json"} -O ${TARGET_FOLDER}"/${MODEL_PATH}/params.json"
     wget --continue ${PRESIGNED_URL/'*'/"${MODEL_PATH}/checklist.chk"} -O ${TARGET_FOLDER}"/${MODEL_PATH}/checklist.chk"
     echo "Checking checksums"
-    (cd ${TARGET_FOLDER}"/${MODEL_PATH}" && md5sum -c checklist.chk)
+    if [ "$CPU_ARCH" = "arm64" ]; then
+      (cd ${TARGET_FOLDER}"/${MODEL_PATH}" && md5 checklist.chk)
+    else
+      (cd ${TARGET_FOLDER}"/${MODEL_PATH}" && md5sum -c checklist.chk)
+    fi
 done


### PR DESCRIPTION
fix the issue that checksum is not working properly in Silicon Mac.