### PR TITLE
More portable shebang for download.sh

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.


### PR DESCRIPTION
`#!/usr/bin/env bash` works on systems that don't have `/bin/bash` such as NixOS.