### PR TITLE
Add "--continue" flag to wget for model binary in order to resume dl

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -56,7 +56,7 @@ do
 
     for s in $(seq -f "0%g" 0 ${SHARD})
     do
-        wget ${PRESIGNED_URL/'*'/"${MODEL_PATH}/consolidated.${s}.pth"} -O ${TARGET_FOLDER}"/${MODEL_PATH}/consolidated.${s}.pth"
+        wget --continue ${PRESIGNED_URL/'*'/"${MODEL_PATH}/consolidated.${s}.pth"} -O ${TARGET_FOLDER}"/${MODEL_PATH}/consolidated.${s}.pth"
     done
 
     wget --continue ${PRESIGNED_URL/'*'/"${MODEL_PATH}/params.json"} -O ${TARGET_FOLDER}"/${MODEL_PATH}/params.json"


### PR DESCRIPTION
"--continue" added to allow downloads to resume with aim of saving bandwidth.

This change brings behavior for this element of the download script into line with codellama download script