### PR TITLE
properly shift tokens for logprobs.

### DIFF
--- a/llama/generation.py
+++ b/llama/generation.py
@@ -178,7 +178,7 @@ class Llama:
             logits = self.model.forward(tokens, prev_pos)
             token_logprobs = -F.cross_entropy(
                 input=logits.transpose(1, 2),
-                target=tokens,
+                target=torch.cat([tokens[:, 1:], torch.full((bsz, 1), pad_id, dtype=torch.long, device="cuda")], dim=1),
                 reduction="none",
                 ignore_index=pad_id,
             )


### PR DESCRIPTION
in `Llama.generate`, the code for logprobs computation when no completion required did not shift token properly. 