### PR TITLE
Fix key-value caching for seqlen != 1 (Issue #899)

### DIFF
--- a/llama/model.py
+++ b/llama/model.py
@@ -289,12 +289,12 @@ class Attention(nn.Module):
         values = self.cache_v[:bsz, : start_pos + seqlen]
 
         # repeat k/v heads if n_kv_heads < n_heads
-        keys = repeat_kv(keys, self.n_rep)  # (bs, seqlen, n_local_heads, head_dim)
-        values = repeat_kv(values, self.n_rep)  # (bs, seqlen, n_local_heads, head_dim)
+        keys = repeat_kv(keys, self.n_rep)  # (bs, cache_len + seqlen, n_local_heads, head_dim)
+        values = repeat_kv(values, self.n_rep)  # (bs, cache_len + seqlen, n_local_heads, head_dim)
 
         xq = xq.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
-        keys = keys.transpose(1, 2)
-        values = values.transpose(1, 2)
+        keys = keys.transpose(1, 2) # (bs, n_local_heads, cache_len + seqlen, head_dim)
+        values = values.transpose(1, 2) # (bs, n_local_heads, cache_len + seqlen, head_dim)
         scores = torch.matmul(xq, keys.transpose(2, 3)) / math.sqrt(self.head_dim)
         if mask is not None:
             scores = scores + mask  # (bs, n_local_heads, seqlen, cache_len + seqlen)

--- a/llama/model.py
+++ b/llama/model.py
@@ -481,8 +481,8 @@ class Transformer(nn.Module):
 
             # When performing key-value caching, we compute the attention scores
             # only for the new sequence. Thus, the matrix of scores is of size
-            # (seq_len, total_len), and the only masked entries are (i, j) for
-            # j > cached_len + i, since row i corresponds to token cached_len + i.
+            # (seqlen, cache_len + seqlen), and the only masked entries are (i, j) for
+            # j > cache_len + i, since row i corresponds to token cache_len + i.
             mask = torch.hstack([
                 torch.zeros((seqlen, start_pos), device=tokens.device),
                 mask


### PR DESCRIPTION
This PR fixes a bug in the key-value caching as described in #899. Currently, a square attention mask is misapplied to the scores matrix despite not matching the shape of the scores matrix. This results in a runtime error. In a correct implementation, the decoder mask needs to describe how the new `seq_len` tokens interact with all the cached tokens. That is, the attention mask needs to be of shape `(seq_len, total_len)`, indicating how the token at row `i` (representing token `i + cached_len` in the transformer model) attends to token `j`. Accordingly, the matrix needs to mask entries where `j > cached_len + i`. This patch horizontally appends `(seq_len, cached_len)` zeros to an upper-triangular mask of size `(seq_len, seq_len)` to form the `(seq_len, total_len)` mask.

This code was tested with the example in issue #899.